### PR TITLE
Allow project to create only one branch for all dependencies update

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,8 +23,7 @@ func main() {
 
 	oneBranchPerDependency := app.Bool(cli.BoolOpt{
 		Name:   "one-branch-per-dependency",
-		Desc:   "one-branch-per-dependency: create one commit and one branch per dependency update" +
-			"",
+		Desc:   "one-branch-per-dependency: create one commit and one branch per dependency update",
 		EnvVar: "ONE_BRANCH_PER_DEPENDENCY",
 		Value:  true,
 	})

--- a/main.go
+++ b/main.go
@@ -150,11 +150,12 @@ func do(githubInfo *github.GithubInfo, mavenRepositoryInfo *maven.RepositoryInfo
 			if err := repo.PushAndCreatePR(branchName, prTitle, prDescription); err != nil {
 				log.Printf("%v\n", err)
 			}
+			prDescription = ""
 		}
 	}
 
 	if !*oneBranchPerDependency {
-		if *dryRun {
+		if !*dryRun {
 			if err := repo.PushAndCreatePR("bump-it-up/bump-them-all", "Bump dependency with group-id: "+*mavenGroupIdFilter, prDescription); err != nil {
 				log.Printf("%v\n", err)
 			}

--- a/main.go
+++ b/main.go
@@ -153,13 +153,13 @@ func do(githubInfo *github.GithubInfo, mavenRepositoryInfo *maven.RepositoryInfo
 		}
 	}
 
-	if *dryRun {
-		log.Printf("%v\n", prDescription)
-	}
-
-	if !*oneBranchPerDependency && !*dryRun {
-		if err := repo.PushAndCreatePR("bump-it-up/bump-them-all", "Bump dependency with group-id: "+*mavenGroupIdFilter, prDescription); err != nil {
-			log.Printf("%v\n", err)
+	if !*oneBranchPerDependency {
+		if *dryRun {
+			if err := repo.PushAndCreatePR("bump-it-up/bump-them-all", "Bump dependency with group-id: "+*mavenGroupIdFilter, prDescription); err != nil {
+				log.Printf("%v\n", err)
+			}
+		} else {
+			log.Printf("%v\n", prDescription)
 		}
 	}
 }


### PR DESCRIPTION
Purpose: creating serveral PR for dependencies update can be time consuming for review or testing

Solution: allow creation of one PR with all dependencies update