### PR TITLE
Remove dry run useless log

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,8 +159,6 @@ func do(githubInfo *github.GithubInfo, mavenRepositoryInfo *maven.RepositoryInfo
 			if err := repo.PushAndCreatePR("bump-it-up/bump-them-all", "Bump dependency with group-id: "+*mavenGroupIdFilter, prDescription); err != nil {
 				log.Printf("%v\n", err)
 			}
-		} else {
-			log.Printf("%v\n", prDescription)
 		}
 	}
 }


### PR DESCRIPTION
When we run a dry ryn with one-branch-per-dependency=false at the end a message was print.
This message is redondant and not usefull so we can remove it